### PR TITLE
SourceClear: fixes for vulnerable libraries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,8 +11,8 @@
 
 	<!-- Component Version Properties -->
 	<properties>
-		<spring.version>4.3.10.RELEASE</spring.version>
-		<fileupload.version>1.3.2</fileupload.version>
+		<spring.version>4.3.20.RELEASE</spring.version>
+		<fileupload.version>1.3.3</fileupload.version>
 	</properties>
 
 	<!-- Dependencies begin here -->
@@ -125,7 +125,7 @@
 		<dependency>
 			<groupId>mysql</groupId>
 			<artifactId>mysql-connector-java</artifactId>
-			<version>5.1.35</version>
+			<version>8.0.16</version>
 		</dependency>
 
 		<dependency>
@@ -136,12 +136,12 @@
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-collections4</artifactId>
-			<version>4.0</version>
+			<version>4.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.struts</groupId>
 			<artifactId>struts2-core</artifactId>
-			<version>2.3.20</version>
+			<version>2.5.22</version>
 		</dependency>
 	</dependencies>
 

--- a/src/main/java/com/veracode/verademo/controller/BlabController.java
+++ b/src/main/java/com/veracode/verademo/controller/BlabController.java
@@ -28,9 +28,43 @@ import com.veracode.verademo.model.Blabber;
 import com.veracode.verademo.model.Comment;
 import com.veracode.verademo.utils.Constants;
 
+
+import java.io.ByteArrayInputStream;
+
 @Controller
 @Scope("request")
 public class BlabController {
+	
+	// start
+	/*
+
+	public class start {
+
+	  public static void main(String[] args) throws Exception {
+	    String candidate = args[0];
+	    String hashed = BCrypt.hashpw(candidate, BCrypt.gensalt(12));
+
+	    BCrypt.checkpw(candidate, hashed);
+
+	    filterXMLSignature();
+
+	    // Update Advisor: changed in the upgrade from Spring Web 3.1.1.RELEASE to 3.2.15.RELEASE
+	    UriUtils.encodeFragment("", "");
+	  }
+
+	  private static void filterXMLSignature() {
+	    byte[] bytes = new byte[256];
+
+	    new MultipartStream(new ByteArrayInputStream(bytes), bytes);
+
+	    new XMLSignatureInput(bytes).addNodeFilter(null);
+	  }
+	}
+	
+	// end
+	*/
+	
+	
 	private static final Logger logger = LogManager.getLogger("VeraDemo:BlabController");
 
 	private final String sqlBlabsByMe = "SELECT blabs.content, blabs.timestamp, COUNT(comments.blabber), blabs.blabid "


### PR DESCRIPTION
This pull request was generated by SourceClear to upgrade the following vulnerable libraries:

| Type | Library | From | To | Breaking |
| --- | --- | --- | --- | --- |
| MAVEN | `org.springframework:spring-web` | 4.3.10.RELEASE | 4.3.20.RELEASE | No |
| MAVEN | `org.springframework:spring-core` | 4.3.10.RELEASE | 4.3.15.RELEASE | No |
| MAVEN | `org.apache.struts:struts2-core` | 2.3.20 | 2.5.22 | No |
| MAVEN | `commons-fileupload:commons-fileupload` | 1.3.2 | 1.3.3 | No |
| MAVEN | `org.springframework:spring-webmvc` | 4.3.10.RELEASE | 4.3.20.RELEASE | No |
| MAVEN | `mysql:mysql-connector-java` | 5.1.35 | 8.0.16 | No |
| MAVEN | `org.apache.commons:commons-collections4` | 4.0 | 4.1 | No |

Note that we only upgrade libraries which have versions without any known vulnerabilities. For more information, please see the corresponding [SourceClear report](https://sca.analysiscenter.veracode.com/teams/lDDI77j/scans/18554153).

The **Breaking** column states the likelihood that updating to the recommended library version will cause breaking changes in your code. Please verify that the changes here won't cause issues with your project before merging.

To learn more about this feature, please visit our [Help Center](https://help.veracode.com/reader/hHHR3gv0wYc2WbCclECf_A/root) for documentation.

Note: this pull request was generated because you or someone else with access to this repository granted SourceClear access to submit pull requests.
<!-- srcclr-pr-id-3b80afc224585cb466d78b80cda7e9ac4fb2e9c02eecc06d4ab6508f7676fb14 -->
